### PR TITLE
Adjust binary file inserts after schema changes

### DIFF
--- a/src/import_from_migration.sql
+++ b/src/import_from_migration.sql
@@ -60,8 +60,8 @@ SELECT eli_norm_manifestation INTO TEMP TABLE inserted_docs FROM inserted_dokume
 INSERT INTO :NORMS_SCHEMA.binary_files (content, eli_dokument_manifestation)
 SELECT content, (ldml_version.manifestation_eli || '/' || attachment.short_filename)
 FROM :MIGRATION_SCHEMA.ldml_version ldml_version
-    JOIN :MIGRATION_SCHEMA.ldml_version_attachment ldml_version_attachment ON ldml_version.id = ldml_version_attachment.ldml_version_id
-    JOIN :MIGRATION_SCHEMA.attachment attachment ON ldml_version_attachment.attachment_id = attachment.id
+    JOIN :MIGRATION_SCHEMA.ldml_version_norm_xml ldml_version_norm_xml ON ldml_version.id = ldml_version_norm_xml.ldml_version_id
+    JOIN :MIGRATION_SCHEMA.attachment attachment ON ldml_version_norm_xml.norm_xml_id = attachment.norm_xml_id
     WHERE ldml_version.manifestation_eli IN (SELECT eli_norm_manifestation FROM inserted_docs)
         AND attachment.short_filename != ''
     ON CONFLICT DO NOTHING;


### PR DESCRIPTION
We have changed the way attachments are linked to a version.

The table `ldml_version_attachment` was replaced with `ldml_version_norm_xml` and each `ldml_version` now has a many-to-many relationship to `norm_xml`. 

Furthermore attachments are now directly linked to its corresponding `norm_xml` via a many-to-one relationship (from the attachment side).

The code changes are still in a PR and the merge should be coordinated. https://github.com/digitalservicebund/ris-norms-migration/pull/250